### PR TITLE
Feature/5 unit tests for coordinates

### DIFF
--- a/cloner/__tests__/deepCloner.spec.js
+++ b/cloner/__tests__/deepCloner.spec.js
@@ -11,8 +11,8 @@ describe('deep copy/cloning', () => {
 
     test('function \'' + functionName + '\'(arg) exist and has one argumnet.', () => {
       // Assert
-      expect(typeof (functionInTest)).toEqual('function');
-      expect(functionInTest.length).toEqual(1);
+      expect(typeof (functionInTest)).toBe('function');
+      expect(functionInTest.length).toBe(1);
     });
 
     // Arrange
@@ -25,7 +25,7 @@ describe('deep copy/cloning', () => {
       [functionInTest, 'function f() {...}']
     ];
 
-    test.each(invalidTestCases)('Invalid Input(%p->%s) should throw Error with message "' + errorMessage + '"', (input, inputStringName) => {
+    test.each(invalidTestCases)('Invalid Input(%p->%s) should throw Error with message "' + errorMessage + '"', (input) => {
       let actualThrownError = null;
 
       // Act
@@ -137,7 +137,7 @@ describe('deep copy/cloning', () => {
 
       // Assert
       // (jsonSample != actual) Just to confrim same memory object is not returned. 
-      // Even with shadow copy it (jsonSample != actual) will pass.
+      // Even with shadow copy it (jsonSample !== actual) will pass.
       expect(jsonSample).not.toBe(actual);
       expect(jsonSample.id).toBe(originalId);
       expect(actual.id).toBe(clonedId);

--- a/cloner/__tests__/deepCloner.spec.js
+++ b/cloner/__tests__/deepCloner.spec.js
@@ -36,7 +36,7 @@ describe('deep copy/cloning', () => {
       }
 
       // Assert
-      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError).not.toBeNull();
       expect(actualThrownError.message).toBe(errorMessage);
     });
 

--- a/coordinates/__tests__/coordinate.spec.js
+++ b/coordinates/__tests__/coordinate.spec.js
@@ -1,0 +1,194 @@
+const Coordinate = require('../coordinate').Coordinate;
+const idealCoordinate = require('../partnersProfile').IdealCoordinate;
+
+describe('Coordinate class tests', () => {
+  describe('Coordinate.constructor(string)', () => {
+    // Arrange (Global for this method only)
+    const errorMessage = 'Given cordinate is not valid.';
+
+    const invalidTestCases = [
+      [null, null],
+      [undefined, undefined],
+      [1, 'AnyNumber'],
+      [{}, '{}(AnyObject)'],
+      ['x,1', 'x,1'],
+      ['x, 1', 'x, 1'],
+      ['1, x', '1,x'],
+      ['x,y', 'x,y'],
+      ['1.5,y', '1.5,y'],
+    ];
+
+    test.each(invalidTestCases)('Invlaid input(%p->%s) -> Coordinate.constructor(string) throws error.', (input) => {
+      // Arrange
+      let actualThrownError = null;
+      let createdCoordinate;
+
+      // Act
+      try {
+        createdCoordinate = new Coordinate(input);
+      } catch (error) {
+        actualThrownError = error;
+      }
+
+      // Assert
+      expect(createdCoordinate).not.toBe(null);
+      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError.message).toBe(errorMessage);
+    });
+
+
+    test('Invlaid string input("any thing which doesn\'t have coma") -> Coordinate.constructor(string) keeps isValid flag to false.', () => {
+      // Arrange
+      const input = 'anystring';
+
+      // Act
+      const actual = new Coordinate(input);
+
+      // Assert
+      expect(actual.isValid).toBeFalsy();
+    });
+
+    const validTestCases = [
+      ['1,2'],
+      ['5.1,2.5'],
+      ['5.1, 2.5']
+    ];
+
+    test.each(validTestCases)('Valid string input("%p") -> Coordinate.constructor(string) keeps isValid flag to true.', (input) => {
+      // Arrange
+      const splitArray = input.split(',');
+      const first = parseFloat(splitArray[0].trim());
+      const second = parseFloat(splitArray[1].trim());
+
+      // Act
+      const actual = new Coordinate(input);
+
+      // Assert
+      expect(actual.isValid).toBeTruthy();
+      expect(actual.x).toBe(first);
+      expect(actual.y).toBe(second);
+    });
+  });
+
+  describe('Coordinate.throwIfInvalid()', () => {
+    test('throws if flag is not valid.', () => {
+      // Arrange
+      const input = 'anystring';
+      let actualThrownError;
+      const errorMessage =
+        'Current cordinates(' + input + ') are not valid. Value: ' + input;
+
+      // Act
+      try {
+        const actual = new Coordinate(input);
+        actual.throwIfInvalid();
+      } catch (error) {
+        actualThrownError = error;
+      }
+
+      // Assert
+      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError.message).toBe(errorMessage);
+    });
+  });
+
+  describe('Coordinate.toString()', () => {
+    test('Coordinate("1, 2") returns given cordinates string("1, 2").', () => {
+      // Arrange
+      const input = '1, 2';
+
+      // Act
+      const actual = new Coordinate(input);
+
+      // Assert
+      expect(actual.toString()).toBe(input);
+    });
+  });
+
+  describe('Coordinate.getDistanceOf(anotherCoordinate) || Coordinate.throwIfInvalid()', () => {
+    const methodsTotest = [
+      'getDistanceOf',
+      'throwIfInvalid'
+    ];
+
+    test.each(methodsTotest)('%p() -> throws if flag is not valid.', (methodName) => {
+      // Arrange
+      const input = 'anystring';
+      let actualThrownError;
+      const errorMessage =
+        'Current cordinates(' + input + ') are not valid. Value: ' + input;
+
+      // Act
+      try {
+        const actual = new Coordinate(input);
+        actual[methodName]();
+      } catch (error) {
+        actualThrownError = error;
+      }
+
+      // Assert
+      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError.message).toBe(errorMessage);
+    });
+
+
+    // Test Cases
+    let anotherCoordinate = new Coordinate(idealCoordinate.coordinates);
+    anotherCoordinate.throwIfInvalid = undefined;
+
+    const inValidTestCasesForGetDistanceOf = [
+      null,
+      undefined,
+      anotherCoordinate,
+    ];
+
+    test.each(inValidTestCasesForGetDistanceOf)('getDistanceOf(%p) -> throws if flag is not valid.', (input) => {
+      // Arrange
+      let actualThrownError;
+      const errorMessage = 'Given cordinates are not valid.';
+
+      // Act
+      try {
+        const actual = new Coordinate(idealCoordinate.coordinates);
+        actual.getDistanceOf(input);
+      } catch (error) {
+        actualThrownError = error;
+      }
+
+      // Assert
+      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError.message).toBe(errorMessage);
+    });
+
+    test('.throwIfInvalid() -> , converterUtility.getDistance() mutation verification and same one return 0 distance.', () => {
+      // Arrange
+      const input = '1, 2';
+      const input2 = '1, 3';
+      const expected = 0;
+      const instance = new Coordinate(input);
+      const anotherInstance = new Coordinate(input2);
+      const throwIfInValidMock = jest.spyOn(instance, 'throwIfInvalid');
+      throwIfInValidMock.mockImplementation(_ => { });
+      // same.getDistanceOf(same) -> 2, another.getDistanceOf(same) -> 1
+      const expectedCallsForthrowIfInValidMock = 3;
+      const expectedCallsForgetDistanceUtilityMock = 1;
+      const converterUtility = require('../../utilities/converterUtility').ConverterUtility;
+      const getDistanceUtilityMock = jest.spyOn(converterUtility, converterUtility.getDistance.name);
+      getDistanceUtilityMock.mockImplementation(_ => 0);
+
+      // Act
+      const actual = instance.getDistanceOf(instance);
+      const actualSecond = anotherInstance.getDistanceOf(instance);
+
+      // Assert
+      expect(actual).toBe(expected);
+      expect(actualSecond).toBe(expected);
+      expect(throwIfInValidMock).toHaveBeenCalledTimes(expectedCallsForthrowIfInValidMock);
+      expect(getDistanceUtilityMock).toHaveBeenCalledTimes(expectedCallsForgetDistanceUtilityMock);
+
+      // Mock-Restore / Tear down
+      throwIfInValidMock.mockRestore();
+      getDistanceUtilityMock.mockRestore();
+    });
+  });
+});

--- a/coordinates/__tests__/coordinate.spec.js
+++ b/coordinates/__tests__/coordinate.spec.js
@@ -31,8 +31,8 @@ describe('Coordinate class tests', () => {
       }
 
       // Assert
-      expect(createdCoordinate).not.toBe(null);
-      expect(actualThrownError).not.toBe(null);
+      expect(createdCoordinate).not.toBeNull();
+      expect(actualThrownError).not.toBeNull();
       expect(actualThrownError.message).toBe(errorMessage);
     });
 
@@ -87,7 +87,7 @@ describe('Coordinate class tests', () => {
       }
 
       // Assert
-      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError).not.toBeNull();
       expect(actualThrownError.message).toBe(errorMessage);
     });
   });
@@ -127,7 +127,7 @@ describe('Coordinate class tests', () => {
       }
 
       // Assert
-      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError).not.toBeNull();
       expect(actualThrownError.message).toBe(errorMessage);
     });
 
@@ -156,7 +156,7 @@ describe('Coordinate class tests', () => {
       }
 
       // Assert
-      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError).not.toBeNull();
       expect(actualThrownError.message).toBe(errorMessage);
     });
 

--- a/coordinates/__tests__/partnersProfile.spec.js
+++ b/coordinates/__tests__/partnersProfile.spec.js
@@ -1,0 +1,275 @@
+const Coordinate = require('../coordinate').Coordinate;
+const idealCoordinate = require('../partnersProfile').IdealCoordinate;
+const PartnersProfile = require('../partnersProfile').PartnersProfile;
+const path = '...';
+const instance = new PartnersProfile(path);
+
+const sampleProfiles = [
+  {
+    "id": 4,
+    "urlName": "blue-square-360",
+    "organization": "Blue Square 360",
+    "customerLocations": "globally",
+    "willWorkRemotely": true,
+    "website": "http://www.bluesquare360.com/",
+    "services": "Blue Square 360 provides a professionally managed service covering all areas of a 360° Feedback initiative. We're experienced in supporting projects of all sizes, and always deliver a personal service that provides the level of support you need to ensure your 360 initiative delivers results for the business.",
+    "offices": [
+      {
+        "location": "Singapore",
+        "address": "Ocean Financial Centre, Level 40, 10 Collyer Quay, Singapore, 049315",
+        "coordinates": "1.28304,103.85199319999992"
+      },
+      {
+        "location": "London, UK",
+        "address": "St Saviours Wharf, London SE1 2BE",
+        "coordinates": "51.5014767,-0.0713608999999451"
+      }
+    ]
+  },
+  {
+    "id": 13,
+    "urlName": "gallus-consulting",
+    "organization": "Gallus Consulting",
+    "customerLocations": "across the UK",
+    "willWorkRemotely": true,
+    "website": "http://www.gallusconsulting.com/",
+    "services": "We're strategy consultants with a difference - we work with organisations and their leaders to take them from strategy to reality. In our work with leaders we often use 360-degree feedback to identify capability gaps, improve self-awareness, and develop strategic and cultural alignment. Our aim is for believe-able leaders to emerge with the drive, capability and cultural fit to take strategy to reality.",
+    "offices": [
+      {
+        "location": "Northampton",
+        "address": "Newton House, Northampton Science Park, Moulton Park, Kings Park Road, Northampton, NN3 6LG",
+        "coordinates": "52.277409,-0.877935999999977"
+      },
+      {
+        "location": "London",
+        "address": "No1 Royal Exchange, London, EC3V 3DG",
+        "coordinates": "51.5136102,-0.08757919999993646"
+      },
+      {
+        "location": "Manchester",
+        "address": "3 Hardman Square, Spinningfields, Manchester, M3 3EB",
+        "coordinates": "53.47990859999999,-2.2510892999999896"
+      }
+    ]
+  },
+];
+
+describe('PartnersProfile class tests', () => {
+  describe('PartnersProfile.constructor(string)', () => {
+    // Arrange (Global for this method only)
+    const errorMessage = 'Given profile path is empty or invalid.';
+
+    const invalidTestCases = [
+      [null, null],
+      [undefined, undefined],
+      [1, 'AnyNumber'],
+      [{}, '{}(AnyObject)'],
+    ];
+
+    test.each(invalidTestCases)('Invlaid input(%p->%s) -> PartnersProfile.constructor(string) throws error.', (input) => {
+      // Arrange
+      let actualThrownError = null;
+      let actual = null;
+
+      // Act
+      try {
+        actual = new PartnersProfile(input);
+      } catch (error) {
+        actualThrownError = error;
+      }
+
+      // Assert
+      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError.message).toBe(errorMessage);
+    });
+
+
+    test('Invlaid string PartnersProfile.constructor(string -> meaning giving invalid path string) -> doesn\'t throw any error.', () => {
+      // Arrange
+      const input = 'anystring,$$##@';
+
+      // Act
+      const actual = new PartnersProfile(input);
+
+      // Assert
+      expect(actual).not.toBe(null);
+      expect(actual).toBeDefined();
+      expect(actual.profilePath).toBe(input);
+    });
+  });
+
+  describe('PartnersProfile.debugPrintPartnerProfilesWithinHundredKilometersOrderByCompanyName() displays ', () => {
+    const expectedMessage = 'No records found within range.';
+    const testCases = [
+      [null, expectedMessage],
+      [undefined, expectedMessage],
+      [[], expectedMessage],
+      [['Hello World1'], 'Hello World1']
+    ]
+
+    test.each(testCases)(`When (%p->%s), prints "%s"`, (returnArray, message) => {
+      // Arrange
+      const mockingMethodName = instance.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay.name;
+      const getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplayMock = jest.spyOn(instance, mockingMethodName);
+      getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplayMock.mockImplementation(_ => returnArray);
+      const consoleLogMock = jest.spyOn(global.console, 'log');
+      consoleLogMock.mockImplementation(_ => { });
+      const expectedCalls = 1;
+      const expectedConsoleCalls = 1;
+
+      // Act
+      instance.debugPrintPartnerProfilesWithinHundredKilometersOrderByCompanyName();
+
+      // Assert
+      expect(consoleLogMock).toHaveBeenCalledTimes(expectedConsoleCalls);
+      expect(consoleLogMock).toHaveBeenCalledWith(message);
+      expect(getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplayMock).toHaveBeenCalledTimes(expectedCalls);
+
+      // Mock-Restore / Tear down
+      consoleLogMock.mockRestore();
+      getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplayMock.mockRestore();
+    });
+  });
+
+  describe('PartnersProfile.partnerProfileOrderByCompanyNameAscending() ascending sorting (f.organization - l.organization) ', () => {
+    const expectedMessage = 'Given profile is either invalid or doesn\' have "organization" property.';
+    const validProfileWithOrganization = { organization: 5 };
+    const validProfileWithOrganization2 = { organization: 3 };
+    const inValidProfileWithOrganization = {};
+    const invalidTestCases = [
+      [[null, null], expectedMessage],
+      [[undefined, undefined], expectedMessage],
+      [[validProfileWithOrganization, undefined], expectedMessage],
+      [[inValidProfileWithOrganization, validProfileWithOrganization], expectedMessage],
+    ]
+
+    test.each(invalidTestCases)(`[Invalid] When (%p->%s), prints "%s"`, (inputArray, message) => {
+      // Arrange
+      const consoleMock = jest.spyOn(global.console, 'error');
+      consoleMock.mockImplementation(_ => { });
+      const expectedConsoleCalls = 1;
+      let actualError = null;
+
+      // Act
+      try {
+        instance.partnerProfileOrderByCompanyNameAscending(inputArray[0], inputArray[1]);
+      } catch (error) {
+        actualError = error;
+      }
+
+      // Assert
+      expect(actualError).not.toBe(null);
+      expect(actualError.message).toBe(message);
+      expect(consoleMock).toHaveBeenCalledTimes(expectedConsoleCalls);
+      expect(consoleMock).toHaveBeenCalledWith(message);
+
+      // Mock-Restore / Tear down
+      consoleMock.mockRestore();
+    });
+
+    test(`[Valid] When (org:5- org:3) returns 2.`, () => {
+      // Arrange
+      const expected = 2;
+
+      // Act
+      const actual = instance.partnerProfileOrderByCompanyNameAscending(validProfileWithOrganization, validProfileWithOrganization2);
+
+      // Assert
+      expect(actual).toBe(expected);
+    });
+  });
+
+  describe('PartnersProfile.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay() gets filtered profiles display array.', () => {
+    test(`[Mutation] getQuickestDistanseProfilesWithinHundredKilometers() must be called at once.`, () => {
+      // Arrange
+      const expectedCalls = 1;
+      const message = 'No filter data found within 100km rage.';
+      const mock = jest.spyOn(instance, instance.getQuickestDistanseProfilesWithinHundredKilometers.name);
+      mock.mockImplementation(_ => []);
+      const consoleMock = jest.spyOn(global.console, 'warn');
+      consoleMock.mockImplementation(_ => { });
+
+      // Act
+      instance.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay();
+
+      // Assert
+      expect(mock).toHaveBeenCalledTimes(expectedCalls);
+      expect(consoleMock).toHaveBeenCalledWith(message);
+
+      // Mock-Restore / Tear down
+      mock.mockRestore();
+      consoleMock.mockRestore();
+    });
+
+    test(`[Integration] getQuickestDistanseProfilesWithinHundredKilometers() creates display string.`, () => {
+      // Arrange
+      const expectedCalls = 1;
+      const mock = jest.spyOn(instance, instance.getQuickestDistanseProfilesWithinHundredKilometers.name);
+      mock.mockImplementation(_ => sampleProfiles);
+
+      // Act
+      const actualResults = instance.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay();
+
+      // Assert
+      expect(mock).toHaveBeenCalledTimes(expectedCalls);
+      expect(actualResults).toBeDefined();
+
+      for (let index = 0; index < actualResults.length; index++) {
+        const profileDisplay = actualResults[index];
+        expect(profileDisplay.indexOf(' Company/Organization Name: "') > -1).toBeTruthy();
+      }
+
+      // Mock-Restore / Tear down
+      mock.mockRestore();
+    });
+  });
+
+  describe('PartnersProfile.getQuickestDistanseProfilesWithinHundredKilometers() gets filtered profiles display array.', () => {
+    test(`[Mutation] getQuickestDistanseProfilesWithinHundredKilometers() must be called at once.`, () => {
+      // Arrange
+      const expectedCalls = 1;
+      const message = 'No filter data found within 100km rage.';
+      const mock = jest.spyOn(instance, instance.getQuickestDistanseProfilesWithinHundredKilometers.name);
+      mock.mockImplementation(_ => []);
+      const consoleMock = jest.spyOn(global.console, 'warn');
+      consoleMock.mockImplementation(_ => { });
+
+      // Act
+      instance.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay();
+
+      // Assert
+      expect(mock).toHaveBeenCalledTimes(expectedCalls);
+      expect(consoleMock).toHaveBeenCalledWith(message);
+
+      // Mock-Restore / Tear down
+      mock.mockRestore();
+      consoleMock.mockRestore();
+    });
+
+    test(`[Integration] getQuickestDistanseProfilesWithinHundredKilometers() creates display string.`, () => {
+      // Arrange
+      const expectedCalls = 1;
+      const mock = jest.spyOn(instance, instance.getQuickestDistanseProfilesWithinHundredKilometers.name);
+      mock.mockImplementation(_ => sampleProfiles);
+
+      // Act
+      const actualResults = instance.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay();
+
+      // Assert
+      expect(mock).toHaveBeenCalledTimes(expectedCalls);
+      expect(actualResults).toBeDefined();
+
+      for (let index = 0; index < actualResults.length; index++) {
+        const profileDisplay = actualResults[index];
+        expect(profileDisplay.indexOf(' Company/Organization Name: "') > -1).toBeTruthy();
+      }
+
+      // Mock-Restore / Tear down
+      mock.mockRestore();
+    });
+  });
+
+  it('idealCoordinate should be "51.515419,-0.141099"', () => {
+    expect(idealCoordinate.coordinates).toBe('51.515419,-0.141099');
+  });
+});

--- a/coordinates/__tests__/partnersProfile.spec.js
+++ b/coordinates/__tests__/partnersProfile.spec.js
@@ -224,51 +224,6 @@ describe('PartnersProfile class tests', () => {
     });
   });
 
-  describe('PartnersProfile.getQuickestDistanseProfilesWithinHundredKilometers() gets filtered profiles display array.', () => {
-    test(`[Mutation] getQuickestDistanseProfilesWithinHundredKilometers() must be called at once.`, () => {
-      // Arrange
-      const expectedCalls = 1;
-      const message = 'No filter data found within 100km rage.';
-      const mock = jest.spyOn(instance, instance.getQuickestDistanseProfilesWithinHundredKilometers.name);
-      mock.mockImplementation(_ => []);
-      const consoleMock = jest.spyOn(global.console, 'warn');
-      consoleMock.mockImplementation(_ => { });
-
-      // Act
-      instance.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay();
-
-      // Assert
-      expect(mock).toHaveBeenCalledTimes(expectedCalls);
-      expect(consoleMock).toHaveBeenCalledWith(message);
-
-      // Mock-Restore / Tear down
-      mock.mockRestore();
-      consoleMock.mockRestore();
-    });
-
-    test(`[Integration] getQuickestDistanseProfilesWithinHundredKilometers() creates display string.`, () => {
-      // Arrange
-      const expectedCalls = 1;
-      const mock = jest.spyOn(instance, instance.getQuickestDistanseProfilesWithinHundredKilometers.name);
-      mock.mockImplementation(_ => sampleProfiles);
-
-      // Act
-      const actualResults = instance.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay();
-
-      // Assert
-      expect(mock).toHaveBeenCalledTimes(expectedCalls);
-      expect(actualResults).toBeDefined();
-
-      for (let index = 0; index < actualResults.length; index++) {
-        const profileDisplay = actualResults[index];
-        expect(profileDisplay.indexOf(' Company/Organization Name: "') > -1).toBeTruthy();
-      }
-
-      // Mock-Restore / Tear down
-      mock.mockRestore();
-    });
-  });
-
   it('idealCoordinate should be "51.515419,-0.141099"', () => {
     expect(idealCoordinate.coordinates).toBe('51.515419,-0.141099');
   });

--- a/coordinates/__tests__/partnersProfile.spec.js
+++ b/coordinates/__tests__/partnersProfile.spec.js
@@ -384,7 +384,7 @@ describe('PartnersProfile class tests', () => {
 
       // Assert
       expect(actual).not.toBeNull();
-      expect(actual).not.toBe(undefined);
+      expect(actual).not.toBeUndefined();
       expect(readFileMock).toHaveBeenCalledTimes(expectedCalls);
       expect(readFileMock).toHaveBeenCalledWith(instance.profilePath);
       expect(actual).toBe(expected);

--- a/coordinates/__tests__/partnersProfile.spec.js
+++ b/coordinates/__tests__/partnersProfile.spec.js
@@ -81,7 +81,7 @@ describe('PartnersProfile class tests', () => {
       }
 
       // Assert
-      expect(actualThrownError).not.toBe(null);
+      expect(actualThrownError).not.toBeNull();
       expect(actualThrownError.message).toBe(errorMessage);
     });
 
@@ -94,7 +94,7 @@ describe('PartnersProfile class tests', () => {
       const actual = new PartnersProfile(input);
 
       // Assert
-      expect(actual).not.toBe(null);
+      expect(actual).not.toBeNull();
       expect(actual).toBeDefined();
       expect(actual.profilePath).toBe(input);
     });
@@ -160,7 +160,7 @@ describe('PartnersProfile class tests', () => {
       }
 
       // Assert
-      expect(actualError).not.toBe(null);
+      expect(actualError).not.toBeNull();
       expect(actualError.message).toBe(message);
       expect(consoleMock).toHaveBeenCalledTimes(expectedConsoleCalls);
       expect(consoleMock).toHaveBeenCalledWith(message);
@@ -383,7 +383,7 @@ describe('PartnersProfile class tests', () => {
       const actual = instance.getPartnerProfiles();
 
       // Assert
-      expect(actual).not.toBe(null);
+      expect(actual).not.toBeNull();
       expect(actual).not.toBe(undefined);
       expect(readFileMock).toHaveBeenCalledTimes(expectedCalls);
       expect(readFileMock).toHaveBeenCalledWith(instance.profilePath);

--- a/coordinates/__tests__/partnersProfile.spec.js
+++ b/coordinates/__tests__/partnersProfile.spec.js
@@ -55,7 +55,7 @@ const sampleProfiles = [
 ];
 
 describe('PartnersProfile class tests', () => {
-  describe('PartnersProfile.constructor(string)', () => {
+  describe('.constructor(string)', () => {
     // Arrange (Global for this method only)
     const errorMessage = 'Given profile path is empty or invalid.';
 
@@ -98,7 +98,7 @@ describe('PartnersProfile class tests', () => {
     });
   });
 
-  describe('PartnersProfile.debugPrintPartnerProfilesWithinHundredKilometersOrderByCompanyName() displays ', () => {
+  describe('.debugPrintPartnerProfilesWithinHundredKilometersOrderByCompanyName() displays ', () => {
     const expectedMessage = 'No records found within range.';
     const testCases = [
       [null, expectedMessage],
@@ -131,7 +131,7 @@ describe('PartnersProfile class tests', () => {
     });
   });
 
-  describe('PartnersProfile.partnerProfileOrderByCompanyNameAscending() ascending sorting (f.organization - l.organization) ', () => {
+  describe('.partnerProfileOrderByCompanyNameAscending() ascending sorting (f.organization - l.organization) ', () => {
     const expectedMessage = 'Given profile is either invalid or doesn\' have "organization" property.';
     const validProfileWithOrganization = { organization: 5 };
     const validProfileWithOrganization2 = { organization: 3 };
@@ -179,7 +179,7 @@ describe('PartnersProfile class tests', () => {
     });
   });
 
-  describe('PartnersProfile.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay() gets filtered profiles display array.', () => {
+  describe('.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay() gets filtered profiles display array.', () => {
     test(`[Mutation] getQuickestDistanseProfilesWithinHundredKilometers() must be called at once.`, () => {
       // Arrange
       const expectedCalls = 1;
@@ -201,7 +201,7 @@ describe('PartnersProfile class tests', () => {
       consoleMock.mockRestore();
     });
 
-    test(`[Integration] getQuickestDistanseProfilesWithinHundredKilometers() creates display string.`, () => {
+    test(`[Integration] creates display string.`, () => {
       // Arrange
       const expectedCalls = 1;
       const mock = jest.spyOn(instance, instance.getQuickestDistanseProfilesWithinHundredKilometers.name);
@@ -221,6 +221,51 @@ describe('PartnersProfile class tests', () => {
 
       // Mock-Restore / Tear down
       mock.mockRestore();
+    });
+  });
+
+  describe('.getQuickestDistanseProfilesWithinHundredKilometers() gets filtered profiles.', () => {
+    test(`[Mutation] getPartnerProfiles() must be called at once.`, () => {
+      // Arrange
+      const expectedCalls = 1;
+      const message = 'No partners profile found';
+      const mock = jest.spyOn(instance, instance.getPartnerProfiles.name);
+      mock.mockImplementation(_ => []);
+      const consoleMock = jest.spyOn(global.console, 'log');
+      consoleMock.mockImplementation(_ => { });
+
+      // Act
+      instance.getQuickestDistanseProfilesWithinHundredKilometers();
+
+      // Assert
+      expect(mock).toHaveBeenCalledTimes(expectedCalls);
+      expect(consoleMock).toHaveBeenCalledWith(message);
+
+      // Mock-Restore / Tear down
+      mock.mockRestore();
+      consoleMock.mockRestore();
+    });
+
+    test(`filterPartnerProfileWithinHundredKilometers() must be called for filtering.`, () => {
+      // Arrange
+      const expectedCalls = 1;
+      const mock = jest.spyOn(instance, instance.getPartnerProfiles.name);
+      mock.mockImplementation(_ => sampleProfiles);
+      const filterMock = jest.spyOn(instance, instance.filterPartnerProfileWithinHundredKilometers.name);
+      filterMock.mockImplementation(_ => true);
+
+      // Act
+      const actualResults = instance.getQuickestDistanseProfilesWithinHundredKilometers();
+
+      // Assert
+      expect(actualResults).toBeDefined();
+      expect(actualResults).toStrictEqual(sampleProfiles);
+      expect(mock).toHaveBeenCalledTimes(expectedCalls);
+      expect(filterMock).toHaveBeenCalledTimes(sampleProfiles.length);
+
+      // Mock-Restore / Tear down
+      mock.mockRestore();
+      filterMock.mockRestore();
     });
   });
 

--- a/coordinates/__tests__/partnersProfile.spec.js
+++ b/coordinates/__tests__/partnersProfile.spec.js
@@ -298,7 +298,7 @@ describe('PartnersProfile class tests', () => {
       getDistanceMock.mockRestore();
     });
 
-    test(`Is NOT within 100km range (> 100KM), adds distance and don't remove from office address.`, () => {
+    test(`Is NOT within 100km range (> 100KM), removes address from the offices array.`, () => {
       // Arrange
       const expectedCalls = 1;
       const getDistanceMock = jest.spyOn(idealCoordinate, 'getDistanceOf');

--- a/coordinates/coordinate.js
+++ b/coordinates/coordinate.js
@@ -1,3 +1,5 @@
+const converterUtility = require('../utilities/converterUtility').ConverterUtility;
+
 class Coordinate {
     constructor(coordinates) {
         if (!coordinates || typeof (coordinates) !== 'string') {
@@ -46,8 +48,6 @@ class Coordinate {
         if(this === anotherCoordinate){
             return 0;
         }
-
-        const converterUtility = require('../utilities/converterUtility').ConverterUtility;
 
         return converterUtility.getDistance(
             this.x,

--- a/coordinates/coordinate.js
+++ b/coordinates/coordinate.js
@@ -1,9 +1,13 @@
 class Coordinate {
     constructor(coordinates) {
+        if (!coordinates || typeof (coordinates) !== 'string') {
+            throw new Error('Given cordinate is not valid.');
+        }
+
         this.coordinates = coordinates;
         const splitter = ',';
 
-        if (!coordinates || coordinates.indexOf(splitter) < 0) {
+        if (coordinates.indexOf(splitter) < 0) {
             this.isValid = false;
             return;
         }
@@ -11,6 +15,14 @@ class Coordinate {
         this.coordinatesArray = coordinates.split(splitter);
         this.x = this.coordinatesArray[0];
         this.y = this.coordinatesArray[1];
+
+        if (isNaN(this.x) || isNaN(this.y) || !this.x || !this.y) {
+            throw new Error('Given cordinate is not valid.');
+        }
+
+        this.x = parseFloat(this.x.trim());
+        this.y = parseFloat(this.y.trim());
+
         this.isValid = true;
     }
 
@@ -18,7 +30,6 @@ class Coordinate {
         if (!this.isValid) {
             const errorMessage =
                 'Current cordinates(' + this.coordinates + ') are not valid. Value: ' + this.coordinates;
-            console.error(errorMessage);
             throw new Error(errorMessage);
         }
     }
@@ -27,11 +38,14 @@ class Coordinate {
         this.throwIfInvalid();
 
         if (!anotherCoordinate || !anotherCoordinate.throwIfInvalid) {
-            throw new Error(
-                'Given cordinates are not valid. Value: ' + this.coordinates);
+            throw new Error('Given cordinates are not valid.');
         }
 
         anotherCoordinate.throwIfInvalid();
+
+        if(this === anotherCoordinate){
+            return 0;
+        }
 
         const converterUtility = require('../utilities/converterUtility').ConverterUtility;
 
@@ -42,7 +56,7 @@ class Coordinate {
             anotherCoordinate.y);
     }
 
-    toString(){
+    toString() {
         return this.coordinates;
     }
 }

--- a/coordinates/partnersProfile.js
+++ b/coordinates/partnersProfile.js
@@ -7,19 +7,11 @@ class PartnersProfile {
      * @param {string} profilePath : Provide an absolute path to the partners file.
      */
     constructor(profilePath) {
-        if (!profilePath) {
+        if (!profilePath || typeof (profilePath) !== 'string') {
             throw new Error('Given profile path is empty or invalid.');
         }
 
         this.profilePath = profilePath;
-    }
-
-    static getIdealCordinate() {
-        return
-    }
-
-    static getIdealCordinateObject() {
-        return new Coordinate(this.getIdealCordinate());
     }
 
     /**
@@ -40,9 +32,11 @@ class PartnersProfile {
             *       However, for this case it is not important.
             *       To keep things simple non-async one is used.
             * */
+
             return require(this.profilePath);
         } catch (error) {
             console.error(error);
+
             return null;
         }
     }
@@ -64,6 +58,7 @@ class PartnersProfile {
         // if any office address within range then returns true for that office
         let returningResult = false;
         const officeAddressesLength = partnerProfile.offices.length;
+
         for (let officeIndex = officeAddressesLength - 1; officeIndex >= 0; officeIndex--) {
             if (this.isCurrentAddressWithinHundredKilomitersRangeExceptDropAddress(partnerProfile, officeIndex)) {
                 returningResult = true;
@@ -103,12 +98,13 @@ class PartnersProfile {
 
         // Note: Not using profiles.filter, because 
         //       this.filterPartnerProfileWithinHundredKilometers calls other functions from inside.
-        if(!profiles || !profiles.length){
+        if (!profiles || !profiles.length) {
             console.log('No partners profile found');
             return;
         }
 
         const results = [];
+
         profiles.forEach(profile => {
             if (this.filterPartnerProfileWithinHundredKilometers(profile)) {
                 results.push(profile);
@@ -119,19 +115,33 @@ class PartnersProfile {
     }
 
     partnerProfileOrderByCompanyNameAscending(firstProfile, secondProfile) {
+        const isInvalid = !firstProfile ||
+            !secondProfile ||
+            !firstProfile.organization ||
+            !secondProfile.organization;
+
+        if (isInvalid) {
+            const message = 'Given profile is either invalid or doesn\' have "organization" property.';
+            console.error(message);
+
+            throw new Error(message);
+        }
+
         return firstProfile.organization - secondProfile.organization;
     }
 
     getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay() {
         const profilesWithinFilter = this.getQuickestDistanseProfilesWithinHundredKilometers();
-        const orderByProfiles = profilesWithinFilter.sort(this.partnerProfileOrderByCompanyNameAscending);
-        if (!orderByProfiles || !orderByProfiles.length) {
+        
+        if (!profilesWithinFilter || !profilesWithinFilter.length) {
             console.warn('No filter data found within 100km rage.');
 
             return;
         }
 
+        const orderByProfiles = profilesWithinFilter.sort(this.partnerProfileOrderByCompanyNameAscending);
         const results = [];
+
         orderByProfiles.forEach(profile => {
             (profile.offices || []).forEach(office => {
                 const distance = office.distance;
@@ -146,6 +156,12 @@ class PartnersProfile {
 
     debugPrintPartnerProfilesWithinHundredKilometersOrderByCompanyName() {
         const profilesDisplay = this.getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay();
+
+        if (!profilesDisplay || !profilesDisplay.length) {
+            console.log('No records found within range.');
+
+            return;
+        }
 
         profilesDisplay.forEach(profileDisplay => {
             console.log(profileDisplay);

--- a/coordinates/partnersProfile.js
+++ b/coordinates/partnersProfile.js
@@ -1,6 +1,7 @@
 const Coordinate = require('./coordinate').Coordinate;
 const idealCoordinateString = '51.515419,-0.141099';
 const idealCoordinate = new Coordinate(idealCoordinateString);
+const fs = require('fs');
 
 class PartnersProfile {
     /**
@@ -14,14 +15,16 @@ class PartnersProfile {
         this.profilePath = profilePath;
     }
 
+    readFileUsingRequire(path) {
+        return require(path);
+    }
+
     /**
      * reading json file from file system and returns the JSON of partners as object.
      */
     getPartnerProfiles() {
-        const fs = require('fs');
-
         if (!fs.existsSync(this.profilePath)) {
-            const errorMessage = 'File (' + this.profilePath + ') doesn\'s exist in the file system.';
+            const errorMessage = `File (${this.profilePath}) doesn't exist in the fil system.`;
             throw new Error(errorMessage);
         }
 
@@ -33,7 +36,7 @@ class PartnersProfile {
             *       To keep things simple non-async one is used.
             * */
 
-            return require(this.profilePath);
+            return this.readFileUsingRequire(this.profilePath);
         } catch (error) {
             console.error(error);
 
@@ -132,7 +135,7 @@ class PartnersProfile {
 
     getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay() {
         const profilesWithinFilter = this.getQuickestDistanseProfilesWithinHundredKilometers();
-        
+
         if (!profilesWithinFilter || !profilesWithinFilter.length) {
             console.warn('No filter data found within 100km rage.');
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
     collectCoverage: true,
-    coverageDirectory: 'coverage'
+    coverageDirectory: 'coverage',
+    verbose: true
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "homepage": "https://github.com/aukgit/Jest-Sample-Test",
   "scripts": {
     "test": "jest --coverage",
-    "dev": "jest --coverage --watchAll"
+    "dev-all": "jest --coverage --watchAll",
+    "dev": "jest --coverage --watch"
   },
   "dependencies": {
     "moment": "2.24.0",

--- a/pbuild.ps1
+++ b/pbuild.ps1
@@ -1,0 +1,28 @@
+
+$currentWorkingDirectory = $PSScriptRoot
+Write-host "---- Automated Build script started ($currentWorkingDirectory) ----" -ForegroundColor Green
+
+function Dev-All-Watch {
+  Write-host "npm run dev-all"
+  npm run dev-all
+}
+
+$isQuickBuild = Read-Host -Prompt 'Do you want to watch all(dev)? [y/n]'
+
+if ($isQuickBuild -eq "y") {
+  Dev-All-Watch
+}
+
+$isQuickBuild = Read-Host -Prompt 'Do you want to watch (dev)? [y/n]'
+
+if ($isQuickBuild -eq "y") {
+  npm run dev
+}
+
+$isQuickBuild = Read-Host -Prompt 'Do you want to run coverage once? [y/n]'
+
+if ($isQuickBuild -eq "y") {
+  npm run test
+}
+
+.\pbuild.ps1

--- a/utilities/__tests__/converterUtility.spec.js
+++ b/utilities/__tests__/converterUtility.spec.js
@@ -1,0 +1,71 @@
+const converterUtility = require('../converterUtility').ConverterUtility;
+const expectedDigitsToMatch = 5;
+
+describe('ConverterUtility class tests.', () => {
+  /**
+   * See reference : https://www.rapidtables.com/convert/number/degrees-to-radians.html
+   */
+  describe('.convertDegreesToRadians(degree) converts given number as degrees to radians', () => {
+    const testCases = [
+      [0, 0],
+      [30, 0.5235987756],
+      [120, 2.0943951024],
+      [360, 6.2831853072]
+    ]
+
+    test.each(testCases)('[Integration] .convertDegreesToRadians(%s) should return %s', (input, expected) => {
+      // Act
+      const actual = converterUtility.convertDegreesToRadians(input);
+
+      // Assert
+      expect(actual).toBeCloseTo(expected, expectedDigitsToMatch);
+    });
+  });
+
+  /**
+   * Reference   : https://en.wikipedia.org/wiki/Great-circle_distance
+   * Reference 2 : https://www.geeksforgeeks.org/program-distance-two-points-earth/
+   * 
+   */
+  describe('.getDistance(lat1, long1, lat2, long2) gives a distance in between coordinates.', () => {
+    const testCases = [
+      [
+        53.32055555555556,
+        -1.7297222222222221,
+        53.31861111111111,
+        -1.6997222222222223,
+        2.0043678382716137 // expected
+      ]
+    ]
+
+    /**
+     * Input : Latitude 1: 53.32055555555556
+     * Longitude 1: -1.7297222222222221
+     * Latitude 2: 53.31861111111111
+     * Longitude 2: -1.6997222222222223
+     * Output: Distance is: 2.0043678382716137 Kilometers
+     */
+    test.each(testCases)('[Integration] .getDistance(lat1:%s, long1: %s, lat2: %s, long2:%s) should return %s', (lat1, long1, lat2, long2, expected) => {
+      // Act
+      const actual = converterUtility.getDistance(lat1, long1, lat2, long2);
+
+      // Assert
+      expect(actual).toBeCloseTo(expected, expectedDigitsToMatch);
+    });
+
+    test('[Mutation with Mock] .getDistance() should call it\'s inner method with expected call numbers', () => {
+      // Arrange 
+      const radiansConverterMock = jest.spyOn(converterUtility, converterUtility.convertDegreesToRadians.name);
+      radiansConverterMock.mockImplementation(_ => 5);
+      const expectedCalls  = 4;
+
+      // Act
+      const actual = converterUtility.getDistance(1, 1, 1, 1);
+
+      // Assert
+      expect(radiansConverterMock).toHaveBeenCalledTimes(expectedCalls);
+      expect(actual).toBe(0);
+    });
+  });
+
+});


### PR DESCRIPTION
# Coordinates and Profile Unit Tests 

- 100% code coverage with mutation and branch coverage.
- Enhanced readability on unit tests assert toBe(null) to toBeNull();

## Screenshots
![image](https://user-images.githubusercontent.com/4561204/76790296-c5fd3200-67e8-11ea-8565-6f9b998cb5da.png)

![image](https://user-images.githubusercontent.com/4561204/76790282-be3d8d80-67e8-11ea-83af-45c8a9373321.png)


## Coverage Report
[lcov-report.zip](https://github.com/aukgit/Jest-Sample-Test/files/4339847/lcov-report.zip)

## Logs
```
Watch Usage: Press w to show more.
 PASS  cloner/__tests__/deepCloner.spec.js
  deep copy/cloning
    DeepCloner.objectToJsonString(object) takes object and converts to string
      √ function 'objectToJsonString'(arg) exist and has one argumnet. (2ms)
      √ Invalid Input(null->null) should throw Error with message "Invalid type null/undefined/function/string/number."
      √ Invalid Input(undefined->undefined) should throw Error with message "Invalid type null/undefined/function/string/number." (1ms)
      √ Invalid Input(1->1) should throw Error with message "Invalid type null/undefined/function/string/number."
      √ Invalid Input(""->EmptyString("" or '')) should throw Error with message "Invalid type null/undefined/function/string/number."
      √ Invalid Input("validString"->validString) should throw Error with message "Invalid type null/undefined/function/string/number."
      √ Invalid Input([Function objectToJsonString]->function f() {...}) should throw Error with message "Invalid type null/undefined/function/string/number." (1ms)
      √ Valid Input({"id": null}) should return "{"id":null}"
      √ Valid Input({"id": ""}) should return "{"id":""}"
      √ Valid Input({}) should return "{}"
      √ Valid Input([]) should return "[]"
      √ Valid Input([[Object], [Object]]) should return "[{"id":null},{}]"
    DeepCloner.deepClone(object) takes object and converts to JSON and then converts that to object (deep cloning).
      √ function 'deepClone'(arg) exist and has one argumnet.
      √ [Mocked, Mutation Test] function 'deepClone'(arg) invokes DeepCloner.objectToJsonString(object) at once. (1ms)
      √ [Integration Test] function 'deepClone'(arg) deep clones to nth level, at least 4th level json is cloned properly tested. (2ms)

 PASS  coordinates/__tests__/coordinate.spec.js
  Coordinate class tests
    Coordinate.constructor(string)
      √ Invlaid input(null->null) -> Coordinate.constructor(string) throws error. (2ms)
      √ Invlaid input(undefined->undefined) -> Coordinate.constructor(string) throws error.
      √ Invlaid input(1->AnyNumber) -> Coordinate.constructor(string) throws error. (1ms)
      √ Invlaid input({}->{}(AnyObject)) -> Coordinate.constructor(string) throws error.
      √ Invlaid input("x,1"->x,1) -> Coordinate.constructor(string) throws error. (1ms)
      √ Invlaid input("x, 1"->x, 1) -> Coordinate.constructor(string) throws error.
      √ Invlaid input("1, x"->1,x) -> Coordinate.constructor(string) throws error.
      √ Invlaid input("x,y"->x,y) -> Coordinate.constructor(string) throws error. (1ms)
      √ Invlaid input("1.5,y"->1.5,y) -> Coordinate.constructor(string) throws error.
      √ Invlaid string input("any thing which doesn't have coma") -> Coordinate.constructor(string) keeps isValid flag to false.
      √ Valid string input(""1,2"") -> Coordinate.constructor(string) keeps isValid flag to true. (1ms)
      √ Valid string input(""5.1,2.5"") -> Coordinate.constructor(string) keeps isValid flag to true. (1ms)
      √ Valid string input(""5.1, 2.5"") -> Coordinate.constructor(string) keeps isValid flag to true.
    Coordinate.throwIfInvalid()
      √ throws if flag is not valid. (1ms)
    Coordinate.toString()
      √ Coordinate("1, 2") returns given cordinates string("1, 2").
    Coordinate.getDistanceOf(anotherCoordinate) || Coordinate.throwIfInvalid()
      √ "getDistanceOf"() -> throws if flag is not valid.
      √ "throwIfInvalid"() -> throws if flag is not valid. (1ms)
      √ getDistanceOf(null) -> throws if flag is not valid.
      √ getDistanceOf(undefined) -> throws if flag is not valid.
      √ getDistanceOf({"coordinates": "51.515419,-0.141099", "coordinatesArray": [Array], "isValid": true, "throwIfInvalid": undefined, "x": 51.515419, "y": -0.141099}) -> throws if flag is not valid. (1ms)
      √ .throwIfInvalid() -> , converterUtility.getDistance() mutation verification and same one return 0 distance. (1ms)

 PASS  coordinates/__tests__/partnersProfile.spec.js
  PartnersProfile class tests
    √ idealCoordinate should be "51.515419,-0.141099"
    √ [Integration] .readFileUsingRequire() throws exception if invalid path given." (20ms)
    .constructor(string)
      √ Invlaid input(null->null) -> PartnersProfile.constructor(string) throws error. (3ms)
      √ Invlaid input(undefined->undefined) -> PartnersProfile.constructor(string) throws error.
      √ Invlaid input(1->AnyNumber) -> PartnersProfile.constructor(string) throws error. (1ms)
      √ Invlaid input({}->{}(AnyObject)) -> PartnersProfile.constructor(string) throws error.
      √ Invlaid string PartnersProfile.constructor(string -> meaning giving invalid path string) -> doesn't throw any error.
    .debugPrintPartnerProfilesWithinHundredKilometersOrderByCompanyName() displays
      √ When (null), prints "No records found within range." (2ms)
      √ When (undefined), prints "No records found within range."
      √ When ([]), prints "No records found within range." (1ms)
      √ When (["Hello World1"]), prints "Hello World1"
    .partnerProfileOrderByCompanyNameAscending() ascending sorting (f.organization - l.organization)
      √ [Invalid] When ([null, null]->Given profile is either invalid or doesn' have "organization" property.), prints "%s" (1ms)
      √ [Invalid] When ([undefined, undefined]->Given profile is either invalid or doesn' have "organization" property.), prints "%s" (1ms)
      √ [Invalid] When ([[Object], undefined]->Given profile is either invalid or doesn' have "organization" property.), prints "%s" (1ms)
      √ [Invalid] When ([[Object], [Object]]->Given profile is either invalid or doesn' have "organization" property.), prints "%s"
      √ [Valid] When (org:5- org:3) returns 2. (1ms)
    .getPartnerProfilesWithinHundredKilometersOrderByCompanyNamesDisplay() gets filtered profiles display array.
      √ [Mutation] getQuickestDistanseProfilesWithinHundredKilometers() must be called at once.
      √ [Integration] creates display string. (1ms)
    .getQuickestDistanseProfilesWithinHundredKilometers() gets filtered profiles.
      √ [Mutation] getPartnerProfiles() must be called at once. (1ms)
      √ filterPartnerProfileWithinHundredKilometers() must be called for filtering. (1ms)
    .isCurrentAddressWithinHundredKilomitersRangeExceptDropAddress(partnerProfile, officeIndex) returns true if within 100Km range and mutates or removes office address from array if not within range.
      √ Is within 100km range, adds distance and don't remove from office address.
      √ Is NOT within 100km range (> 100KM), adds distance and don't remove from office address. (1ms)
    .getPartnerProfiles() reads profile json data file from file system.
      √ [Using Mock] Throws error if given path is not exist in the system. (1ms)
      √ [Integration] Throws error if given path is not exist in the system.
      √ [Valid Path, Using Mock] Returns JSON data.
      √ [Valid Path, Using Mock] Returns null and console log while have error during read. (1ms)
    .filterPartnerProfileWithinHundredKilometers() returns true if any address is within range of 100km from IdealCoordinate(51.515419,-0.141099).
      √ [Invalid, Integration] Returns false 'office' property doesn't exist 'office'(undefined/null/[]) or profile is undefined/null.
      √ [Valid Input, Using Mock] If office address coordinate is not within range then returns false.
      √ [Valid Input, Using Mock] If office (any) address coordinate is not within range then returns 'true'.

 PASS  utilities/__tests__/converterUtility.spec.js
  ConverterUtility class tests.
    .convertDegreesToRadians(degree) converts given number as degrees to radians
      √ [Integration] .convertDegreesToRadians(0) should return 0 (2ms)
      √ [Integration] .convertDegreesToRadians(30) should return 0.5235987756
      √ [Integration] .convertDegreesToRadians(120) should return 2.0943951024
      √ [Integration] .convertDegreesToRadians(360) should return 6.2831853072 (1ms)
    .getDistance(lat1, long1, lat2, long2) gives a distance in between coordinates.
      √ [Integration] .getDistance(lat1:53.32055555555556, long1: -1.7297222222222222, lat2: 53.31861111111111, long2:-1.6997222222222224) should return 2.0043678382716137
      √ [Mutation with Mock] .getDistance() should call it's inner method with expected call numbers (1ms)

----------------------|---------|----------|---------|---------|-------------------
File                  | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
----------------------|---------|----------|---------|---------|-------------------
All files             |     100 |    98.53 |     100 |     100 |
 cloner               |     100 |      100 |     100 |     100 |
  deepCloner.js       |     100 |      100 |     100 |     100 |
 coordinates          |     100 |    98.25 |     100 |     100 |
  coordinate.js       |     100 |      100 |     100 |     100 |
  partnersProfile.js  |     100 |     97.3 |     100 |     100 | 112
 utilities            |     100 |      100 |     100 |     100 |
  converterUtility.js |     100 |      100 |     100 |     100 |
----------------------|---------|----------|---------|---------|-------------------
Test Suites: 4 passed, 4 total
Tests:       71 passed, 71 total
Snapshots:   0 total
Time:        6.967s
Ran all test suites.
```